### PR TITLE
separated compute_scores in parse arguments and functions

### DIFF
--- a/lib/osop/compute_products_func.py
+++ b/lib/osop/compute_products_func.py
@@ -1,3 +1,4 @@
+# Ensure the top level directory has been added to PYTHONPATH
 # Libraries for working with multi-dimensional arrays
 import xarray as xr
 import pandas as pd
@@ -8,11 +9,9 @@ import eccodes
 # Date and calendar libraries
 from dateutil.relativedelta import relativedelta
 
-import argparse
 
 
-# Ensure the top level directory has been added to PYTHONPATH
-from osop.constants import SYSTEMS
+
 
 
 def calc_anoms(hcst_fname, hcst_bname, config, st_dim_name, datadir):

--- a/lib/osop/compute_scores_func.py
+++ b/lib/osop/compute_scores_func.py
@@ -4,16 +4,14 @@
 import xarray as xr
 import pandas as pd
 import numpy as np
-import os
+
 
 # Forecast verification metrics with xarray
 import xskillscore as xs
 
+#import needed local functions
 from osop.compute_products_func import get_thresh
 
-import argparse
-
-from osop.constants import SYSTEMS
 
 
 def read_obs(obs_fname, config):

--- a/lib/osop/plot_verify.py
+++ b/lib/osop/plot_verify.py
@@ -1,6 +1,5 @@
 # Libraries for working with multi-dimensional arrays
 import xarray as xr
-import pandas as pd
 import numpy as np
 import os
 
@@ -8,15 +7,11 @@ import os
 from matplotlib import pyplot as plt
 import cartopy.crs as ccrs
 import cartopy.feature as cfeature
-
-# Disable warnings for data download via API and matplotlib (do I need both???)
-import warnings
 from cartopy import crs as ccrs
 import calendar
 
-import argparse
 
-from osop.constants import SYSTEMS
+
 
 CATNAMES = ["lower tercile", "middle tercile", "upper tercile"]
 

--- a/scripts/compute_products.py
+++ b/scripts/compute_products.py
@@ -1,21 +1,10 @@
-# Libraries for working with multi-dimensional arrays
-import xarray as xr
-import pandas as pd
-import numpy as np
-import os
-import eccodes
-
-# Date and calendar libraries
-from dateutil.relativedelta import relativedelta
-
+# Ensure the top level directory has been added to PYTHONPATH
 import argparse
 
 
-# Ensure the top level directory has been added to PYTHONPATH
-from osop.constants import SYSTEMS
-
 #import needed local functions
-from osop.compute_products_func import calc_products, get_thresh
+from osop.constants import SYSTEMS
+from osop.compute_products_func import calc_products
 
 
 def parse_args():

--- a/scripts/compute_scores.py
+++ b/scripts/compute_scores.py
@@ -1,19 +1,14 @@
 # This script currently can only be used to create scores using ERA5 as the comparison dataset
-
-# Libraries for working with multi-dimensional arrays
-import xarray as xr
-import pandas as pd
-import numpy as np
 import os
 
-# Forecast verification metrics with xarray
-import xskillscore as xs
-
+#import local modules for function usage 
 from osop.compute_scores_func import calc_scores
+from osop.constants import SYSTEMS
 
+# Ensure the top level directory has been added to PYTHONPATH
 import argparse
 
-from osop.constants import SYSTEMS
+
 
 
 def parse_args():

--- a/scripts/plot_verification.py
+++ b/scripts/plot_verification.py
@@ -1,21 +1,6 @@
-# Libraries for working with multi-dimensional arrays
-import xarray as xr
-import pandas as pd
-import numpy as np
-import os
-
-# Libraries for plotting and geospatial data visualisation
-from matplotlib import pyplot as plt
-import cartopy.crs as ccrs
-import cartopy.feature as cfeature
-
-# Disable warnings for data download via API and matplotlib (do I need both???)
-import warnings
-from cartopy import crs as ccrs
-import calendar
-
+# Ensure the top level directory has been added to PYTHONPATH
 import argparse
-
+#import needed local functions
 from osop.constants import SYSTEMS
 from osop.plot_verify import generate_plots, prep_titles
 


### PR DESCRIPTION
Separated compute_scores.py into compute_scores_func.py and compute_scores.py. 
-removed import compute_products : get_thresh as not being used. 

Checks: 
Successful run of master.test.sh
Successful run of master.sh 
Comparison of plot outputs before and after change : specifics (ukmo_602_1993-2016_monthly_mean_11_234_45\:-30\:-2.5\:60_2m_temperature.3m.bs.nc_category_0.png & ncep_2_1993-2016_monthly_mean_11_234_45:-30:-2.5:60_2m_temperature.3m.roc.nc_category_0.png) 