### PR TITLE
#issue 24 - added border query

### DIFF
--- a/lib/osop/plot_verify.py
+++ b/lib/osop/plot_verify.py
@@ -12,7 +12,6 @@ import calendar
 
 
 
-
 CATNAMES = ["lower tercile", "middle tercile", "upper tercile"]
 
 
@@ -56,7 +55,7 @@ def prep_titles(config):
     return tit_line1, tit_line2, tit_line3
 
 
-def plot_score(score_f, score_fname, category, config, score, titles, datadir):
+def plot_score(border, score_f, score_fname, category, config, score, titles, datadir):
     """
     Plot the score on a map.
 
@@ -168,8 +167,13 @@ def plot_score(score_f, score_fname, category, config, score, titles, datadir):
         cmap=cols,
         extend=ex_dir,
     )
+    
+    
     cs.cmap.set_under(under)
+    if border == "true":
+        ax.add_feature(cfeature.BORDERS, edgecolor="black", linewidth=0.5)
     ax.add_feature(cfeature.COASTLINE, edgecolor="black", linewidth=2.0)
+
 
     print(info)
     plt.colorbar()
@@ -220,7 +224,7 @@ def plot_rel(score_f, score_fname, config, score, datadir, titles):
         plt.close()
 
 
-def corr_plots(datadir, hcst_bname, aggr, config, titles):
+def corr_plots(border, datadir, hcst_bname, aggr, config, titles):
     """Plot deterministic scores
     Parameters:
     datadir (str): The directory to save the plot.
@@ -243,10 +247,12 @@ def corr_plots(datadir, hcst_bname, aggr, config, titles):
     ).sortby("lon")
 
     # Set up the figure and axes
-
+    
     fig = plt.figure(figsize=(18, 10))
     ax = plt.axes(projection=ccrs.PlateCarree())
     ax.add_feature(cfeature.COASTLINE, edgecolor="black", linewidth=2.0)
+    if border == "true":
+        ax.add_feature(cfeature.BORDERS, edgecolor="black", linewidth=0.5)
 
     corrvalues = corr[config["var"]][0, :, :].values
     corrpvalvalues = corr_pval[config["var"]][0, :, :].values
@@ -304,7 +310,7 @@ def corr_plots(datadir, hcst_bname, aggr, config, titles):
     plt.close()
 
 
-def generate_plots(config, titles, downloaddir):
+def generate_plots(border, config, titles, downloaddir):
     ## read in the data
     score_fname = "{origin}_{system}_{hcstarty}-{hcendy}_monthly_mean_{start_month}_{leads_str}_{area_str}_{fname_var}.{aggr}.{score}.nc".format(
         **config
@@ -315,19 +321,19 @@ def generate_plots(config, titles, downloaddir):
         score_fname = "{origin}_{system}_{hcstarty}-{hcendy}_monthly_mean_{start_month}_{leads_str}_{area_str}_{fname_var}".format(
             **config
         )
-        corr_plots(downloaddir, score_fname, config["aggr"], config, titles)
+        corr_plots(border, downloaddir, score_fname, config["aggr"], config, titles)
 
     elif config["score"] == "rel":
         plot_rel(score_data, score_fname, config, config["score"], downloaddir, titles)
 
     elif config["score"] == "rps":
-        plot_score(score_data, score_fname, None, config, config["score"], titles, downloaddir)
+        plot_score(border, score_data, score_fname, None, config, config["score"], titles, downloaddir)
 
     elif config["score"] == "bs":
         for cat in [0, 1, 2]:
-            plot_score(score_data, score_fname, cat, config, config["score"], titles, downloaddir)
+            plot_score(border,score_data, score_fname, cat, config, config["score"], titles, downloaddir)
 
     else:
         for cat in [0, 1, 2]:
             config["category"] = cat
-            plot_score(score_data, score_fname, cat, config, config["score"], titles, downloaddir)
+            plot_score(border, score_data, score_fname, cat, config, config["score"], titles, downloaddir)

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -37,6 +37,15 @@ leads="2,3,4" # e.g. if month=5 and leads="2,3,4", valid months are JJA (6,7,8)
 area="45,-30,-2.5,60" # sub-area in degrees for area of interest (comma separated N,W,S,E)
 variable="2m_temperature" # variable of interest, typically "2m_temperature" or "total_precipitation"
 
+#Query wether user wants borders 
+echo "Do you want borders? type 1 for yes and 2 for no"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) border="true"; echo "Borders added"; break;;
+        No ) border="false"; echo "Borders removed"; break;;
+    esac
+done
+
 # get ERA5 data
 set +e
 python get_era5.py \
@@ -109,6 +118,7 @@ for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc ;do
     # plot scores
         set +e
     python plot_verification.py \
+        --border $border \
         --centre $centre \
         --month $month \
         --leads $leads \

--- a/scripts/master.test.sh
+++ b/scripts/master.test.sh
@@ -35,6 +35,15 @@ leads="2,3,4" # e.g. if month=5 and leads="2,3,4", valid months are JJA (6,7,8)
 area="45,-30,-2.5,60" # sub-area in degrees for area of interest (comma separated N,W,S,E)
 variable="total_precipitation" # variable of interest, typically "2m_temperature" or "total_precipitation"
 
+#Query wether user wants borders 
+echo "Do you want borders? type 1 for yes and 2 for no"
+select yn in "Yes" "No"; do
+    case $yn in
+        Yes ) border="true"; echo "Borders added"; break;;
+        No ) border="false"; echo "Borders removed"; break;;
+    esac
+done
+
 # get ERA5 data
 set +e
 python get_era5.py \
@@ -108,6 +117,7 @@ for centre in meteo_france ;do
     # plot scores
         set +e
     python plot_verification.py \
+        --border $border \
         --centre $centre \
         --month $month \
         --leads $leads \

--- a/scripts/plot_verification.py
+++ b/scripts/plot_verification.py
@@ -16,6 +16,7 @@ def parse_args():
     """
 
     parser = argparse.ArgumentParser()
+    parser.add_argument("--border", required=True)
     parser.add_argument("--centre", required=True, help="centre to download")
     parser.add_argument("--month", required=True, help="start month for hindcasts")
     parser.add_argument(
@@ -54,6 +55,7 @@ if __name__ == "__main__":
     args = parse_args()
 
     # unpack args and reformat if needed
+    border = args.border
     centre = args.centre
     downloaddir = args.downloaddir
     month = int(args.month)
@@ -76,6 +78,7 @@ if __name__ == "__main__":
 
     # add arguments to config
     config = dict(
+        border = border,
         start_month=month,
         valid_month=valid_month,
         origin=centre,
@@ -104,17 +107,17 @@ if __name__ == "__main__":
                 config["system"] = SYSTEMS["eccc_can"]
                 ## set titles
                 titles = prep_titles(config)
-                generate_plots(config, titles, downloaddir)
+                generate_plots(border, config, titles, downloaddir)
 
                 ## repeat for second system
                 config["system"] = SYSTEMS["eccc_gem5"]
                 ## set titles
                 titles = prep_titles(config)
-                generate_plots(config, titles, downloaddir)
+                generate_plots(border, config, titles, downloaddir)
             else:
                 if centre not in SYSTEMS.keys():
                     raise ValueError(f"Unknown system for C3S: {centre}")
                 config["system"] = SYSTEMS[centre]
                 ## set titles
                 titles = prep_titles(config)
-                generate_plots(config, titles, downloaddir)
+                generate_plots(border, config, titles, downloaddir)


### PR DESCRIPTION
Added a border query in both master.test.sh and master.sh
this runs a true or false through plot_verification then onto plot_verify and this into the functions corr_plots and plot_scores. If the query is set to true will add borders and false will skip the code and thus leave them removed. This is open ended atm to leave room for adding country perspective. 

tests include:

complete running of master.test.sh and master.sh
both run fully as before if 1 entered will plot borders and if 2 will not, any other input will repeat enquiry till 1 or 2 is inputted.
Plots compared when 1 and 2 was selected against 2 plot outputs from before changes were made. Plots came back identical except if borders were added. 

Before merge aim to add country selection query.

borders added 
![image](https://github.com/user-attachments/assets/76f4f266-30ee-46d6-8ca0-7177262961fe)
the before changes of same plot
![image](https://github.com/user-attachments/assets/d5f49b80-af63-48de-a340-873cea27f038)

issue notes:
ncep : product generation failed
ncep : score generation failed
ncep : plots generated
....
jma : products generated
jma : score generation failed
jma : plot generation failed
both of these are happening in the master branch without the changes pushed. 
