### PR TITLE
#issue 23   remove nc + #issue 30 add variable to plot title

### DIFF
--- a/lib/osop/plot_verify.py
+++ b/lib/osop/plot_verify.py
@@ -114,6 +114,7 @@ def plot_score(
     score (str): The name of the score.
     titles (list): Titles for the plot.
     datadir (str): The directory to save the plot.
+    score_title (str): The name for the plot in the file directory.
 
     Returns:
     None
@@ -266,7 +267,8 @@ def plot_rel(score_f, score_fname, config, score, datadir, titles, score_title):
     config (dict): Configuration parameters.
     score (str): The name of the score.
     datadir (str): The directory to save the plot.
-
+    score_title (str): The name for the plot in the file directory.
+    
     Returns:
     None
     """


### PR DESCRIPTION
STATUS: Review

CHANGES:
nc removed from png filenames. The nc typing was coming from score_fname; that had the nc saved in (at the start of func generate plots) . Since score_f_name was in use throughout the file in occasion a new function input was added that was score_title. This essentially is just score_f_name repeated but without the nc and is used in the save fig + category components of functions. The variable is assigned at the start of generate plots. Theoretically the score_f_name could of just been changed and it would of worked without issue - so this does edge on redundancy however, the method used leaves it open for easier edits or continued flexibility.  

CHECKS:
Files have been compared before and after. All files present with the only variation being nc removed from the filename of the plots. Plots have compared before and after for the sake of sanity checking - they are the same. 
Black has been run on the code for clarity.
Master.sh and Master.test.sh have both been run to completion without error. 

closes #23 
