### PR TITLE
Fixed determnisitc issues for JMA

### DIFF
--- a/lib/osop/compute_scores_func.py
+++ b/lib/osop/compute_scores_func.py
@@ -102,7 +102,7 @@ def swap_dims(hcst, obs):
 
         return thishcst, thisobs
 
-def align_data(thishcst, this_obs):
+def regrid_data(input_ds, target_ds):
     """
     Regrids the dataset appropriatley for its type (planned expansion for percipertation)
 
@@ -115,13 +115,13 @@ def align_data(thishcst, this_obs):
     thisobs (xarray.Dataset): Matching obs dataset (no changes)
     """
     try:
-        regridder =  xe.Regridder(thishcst, this_obs, "bilinear")
-        thishcst = regridder(thishcst, keep_attrs=True)
+        regridder =  xe.Regridder(input_ds, target_ds, "bilinear")
+        input_ds = regridder(input_ds, keep_attrs=True)
     except Exception as e:
                 print(f"Alignment failed {e}: {e}")
                 raise KeyError("Alignment failed: please check dataset entry")    
     
-    return thishcst, this_obs
+    return input_ds, target_ds
 
 
 
@@ -175,9 +175,9 @@ def scores_dtrmnstc(obs_ds, obs_ds_3m, hcst_bname, scoresdir, productsdir):
         )
          # Regrid if lattitude or longitude on a varied resolution or grid. 
         if not thishcst_em_mean['lat'].equals(this_obs_m_match['lat']) or not thishcst_em_mean['lon'].equals(this_obs_m_match['lon']):
-            thishcst_em_mean, this_obs_m_match = align_data(thishcst_em_mean, this_obs_m_match)
+            thishcst_em_mean, this_obs_m_match = regrid_data(thishcst_em_mean, this_obs_m_match)
         if not thishcst_em_anom['lat'].equals(this_obs_anom['lat']) or not thishcst_em_anom['lon'].equals(this_obs_anom['lon']):
-            thishcst_em_anom, this_obs_anom = align_data(thishcst_em_anom, this_obs_anom)
+            thishcst_em_anom, this_obs_anom = regrid_data(thishcst_em_anom, this_obs_anom)
 
 
         # calculate measures
@@ -275,7 +275,7 @@ def scores_prblstc(obs_ds, obs_ds_3m, hcst_bname, scoresdir, productsdir):
 
             # Regrid if lattitude or longitude on a varied resolution or grid. 
             if not thishcst['lat'].equals(thisobs['lat']) or not thishcst['lon'].equals(thisobs['lon']):
-               thishcst, thisobs = align_data(thishcst,thisobs)
+               thishcst, thisobs = regrid_data(thishcst,thisobs)
 
             # Calculate the probabilistic scores
             thisroc = xr.Dataset()

--- a/lib/osop/compute_scores_func.py
+++ b/lib/osop/compute_scores_func.py
@@ -107,21 +107,21 @@ def regrid_data(input_ds, target_ds):
     Regrids the dataset appropriatley for its type (planned expansion for percipertation)
 
     Parameters:
-    thishcst (xarray.Dataset): Hindcast data for regrid
-    thisobs (xarray.Dataset): Matching obs dataset to be set as the target
+    input_ds (xarray.Dataset): Data to be re-gridded
+    target_ds (xarray.Dataset): Data set with the target grid
 
     Returns:
-    thishcst (xarray.Dataset): Regridded dataset to be used for analysis
-    thisobs (xarray.Dataset): Matching obs dataset (no changes)
+    output_ds (xarray.Dataset): Regridded dataset to be used for analysis
+    target_ds (xarray.Dataset): Matching target dataset (no changes)
     """
     try:
         regridder =  xe.Regridder(input_ds, target_ds, "bilinear")
-        input_ds = regridder(input_ds, keep_attrs=True)
+        output_ds = regridder(input_ds, keep_attrs=True)
     except Exception as e:
                 print(f"Alignment failed {e}: {e}")
                 raise KeyError("Alignment failed: please check dataset entry")    
     
-    return input_ds, target_ds
+    return output_ds, target_ds
 
 
 


### PR DESCRIPTION
**CURRENT STATUS**: _Ready for review._
**AIM**: Get JMA plotting deterministic verification measures.
**PROBLEM**: After the conclusion of the PR JMA issue, JMA was plotting all probabilistic measures. The issue there (as well as here) was that the dataset did not match in resolution (varying lon, lat to the obs dataset). This fix needed applying to the deterministic measures. Tackling now allows it to include the changes that were merged with the ACC implementation. Needed as the deterministic measures now runs over more than one dataset at one time (this hcst mean and this hcst anom) which was not merged in before the JMA issue resolution. 
**CHANGES**: The deterministic measures in compute scores now aligns/interpolates via the exsmf regridder, using the bilinear method. This may be expanded in future to include different methods for precipitation and 2m temperature. The alignment/interpolation has now become its own function as oppose to embedded within the probabilistic measures called align_data. The function reduces repetition over the code but generally is smaller and only includes an alignment for the data. The new function has been fitted into the probabilistic measures smoothly.
**CHECKS**: The pearson(acc), spearman and roc score has been checked against the verifications produced by ecmwf :https://confluence.ecmwf.int/display/CKB/C3S+seasonal+forecasts+verification+plots 
for met office glosea6, jma and meteo france. All plots are coming out as expected and match effectively, this is true for both 2m temp and precipitation. 