### PR TITLE
Yml

### DIFF
--- a/scripts/compute_scores.py
+++ b/scripts/compute_scores.py
@@ -18,47 +18,6 @@ from osop.compute_scores_func import calc_scores
 
 
 # Ensure the top level directory has been added to PYTHONPATH
-import argparse
-
-
-
-
-def parse_args():
-    """
-    set up argparse to get command line arguments
-
-    Returns:
-        args: argparse args object
-    """
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--centre", required=True, help="centre to download")
-    parser.add_argument(
-        "--obs_dataset", required=False,
-        help="name of observation or reanalysis dataset. Optional. Defaults to ERA5")
-    parser.add_argument("--month", required=True, help="start month for hindcasts")
-    parser.add_argument(
-        "--variable", required=True, help="variable to verify. t2m or tprate"
-    )
-    parser.add_argument(
-        "--leads", required=True, help="forecast range in months (comma separated)"
-    )
-    parser.add_argument(
-        "--area",
-        required=True,
-        help="sub-area in degrees for retrieval (comma separated N,W,S,E)",
-    )
-    parser.add_argument("--downloaddir", required=True, help="location to get grib from")
-    parser.add_argument("--scoresdir", required=True, help="location to download to")
-    parser.add_argument("--productsdir", required=True, help="location to get products from")
-    parser.add_argument(
-        "--years",
-        required=False,
-        help="Years to rerieve data for (comma separated). Optional. Default is hindcast period 1993-2016.",
-    )
-
-    args = parser.parse_args()
-    return args
 
 
 if __name__ == "__main__":
@@ -70,23 +29,49 @@ if __name__ == "__main__":
     calculation of verification metrics
     """
 
+
     # get command line args
-    args = parse_args()
+    ymllocation = os.path.join("variables.yml")
+    with open(ymllocation, "r") as stream:
+        try:
+            print('yml found')
+            # Converts yaml document to python object
+            config_test = yaml.load(stream, Loader=SafeLoader)
+            # Converts contents to useable dictionary
+            Services = config_test["Services"]
+            Month_test = config_test["month"]
+            leads_test = config_test["leads"]
+            area_test = config_test["area"]
+            varaible_test = config_test["variable"]
+            downloaddir_test = config_test["downloaddir"]
+            scoresdir = config_test["scoresdir"]
+            productsdir = config_test["productsdir"]
+            years = config_test["years"]
+            centre = config_test["centre"]
+            obs = config_test["obs"]
+            print('yml success')
+        except yaml.YAMLError as e:
+            print(e)
+
+    downloaddir_test = os.path.expandvars(downloaddir_test)
+    scoresdir= os.path.expandvars(scoresdir)
+    productsdir = os.path.expandvars(productsdir)
+    os.makedirs(scoresdir, exist_ok=True)
 
     # unpack args and reformat if needed
-    centre = args.centre
-    downloaddir = args.downloaddir
-    scoresdir = args.scoresdir
-    productsdir = args.productsdir
-    month = int(args.month)
-    leads = args.leads
-    leadtime_month = [int(l) for l in args.leads.split(",")]
+    centre = centre
+    downloaddir = downloaddir_test
+    scoresdir = scoresdir
+    productsdir = productsdir
+    month = int(Month_test)
+    leads = leads_test
+    leadtime_month = [int(l) for l in leads_test.split(",")]
     leads_str = "".join([str(mon) for mon in leadtime_month])
-    obs_month = [int(l) - 1 for l in args.leads.split(",")]
+    obs_month = [int(l) - 1 for l in leads_test.split(",")]
     obs_str = "".join([str(mon) for mon in obs_month])
-    area = [float(pt) for pt in args.area.split(",")]
-    area_str = args.area.replace(",", ":")
-    hc_var = args.variable
+    area = [float(pt) for pt in area_test.split(",")]
+    area_str = area_test.replace(",", ":")
+    hc_var = varaible_test
 
     if hc_var == "2m_temperature":
         var = "t2m"
@@ -98,7 +83,6 @@ if __name__ == "__main__":
     # add arguments to config
     config = dict(
         start_month=month,
-        origin=centre,
         area_str=area_str,
         leads_str=leads_str,
         leads=leadtime_month,
@@ -106,42 +90,33 @@ if __name__ == "__main__":
         var=var,
         hc_var=hc_var,
     )
-    # get remaning arguments from yml file
-    ymllocation = os.path.join(downloaddir, "parseyml.yml")
-
-    with open(ymllocation, "r") as stream:
-        try:
-            # Converts yaml document to python object
-            services = yaml.load(stream, Loader=SafeLoader)
-            # Converts contents to useable dictionary
-            Services = services["Services"]
-        except yaml.YAMLError as e:
-            print(e)
-
-    if args.years:
-        config["hcstarty"] = args.years[0]
-        config["hcendy"] = args.years[1]
+    
+    if years:
+        config["hcstarty"] = years[0]
+        config["hcendy"] = years[1]
     else:
         config["hcstarty"] = 1993
         config["hcendy"] = 2016
     
-    if args.obs_dataset:
-        config['obs_name'] = args.obs
+    if obs:
+        config['obs_name'] = obs
     else:
         config['obs_name'] = 'era5'
 
 
     # hindcast info
-    if centre == "eccc":
-        # two models aka systems are live - call twice with each system number
-        config["system"] = Services["eccc_can"]
-        calc_scores(config, downloaddir, scoresdir, productsdir)
+    for centre in config_test["centre"]:
+        config["origin"] = centre
+        if centre == "eccc":
+            # two models aka systems are live - call twice with each system number
+            config["system"] = Services["eccc_can"]
+            calc_scores(config, downloaddir, scoresdir, productsdir)
 
-        ## repeat for second system
-        config["system"] = Services["eccc_gem5"]
-        calc_scores(config, downloaddir, scoresdir, productsdir)
-    else:
-        if centre not in Services.keys():
-            raise ValueError(f"Unknown system for C3S: {centre}")
-        config["system"] = Services[centre]
-        calc_scores(config, downloaddir, scoresdir, productsdir)
+            ## repeat for second system
+            config["system"] = Services["eccc_gem5"]
+            calc_scores(config, downloaddir, scoresdir, productsdir)
+        else:
+            if centre not in Services.keys():
+                raise ValueError(f"Unknown system for C3S: {centre}")
+            config["system"] = Services[centre]
+            calc_scores(config, downloaddir, scoresdir, productsdir)

--- a/scripts/get_any_hindcast.py
+++ b/scripts/get_any_hindcast.py
@@ -20,7 +20,6 @@ Usage:
 """
 
 import cdsapi
-import argparse
 import os
 import yaml
 from yaml.loader import SafeLoader
@@ -110,41 +109,6 @@ def do_cdsapi_call(
         )
 
 
-def parse_args():
-    """
-    set up argparse to get command line arguments
-
-    Returns:
-        args: argparse args object
-    """
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--centre", required=True, help="centre to download")
-    parser.add_argument("--month", required=True, help="start month for hindcasts")
-    parser.add_argument(
-        "--leads", required=True, help="forecast range in months (comma separated)"
-    )
-    parser.add_argument(
-        "--area",
-        required=True,
-        help="sub-area in degrees for retrieval (comma separated N,W,S,E)",
-    )
-    parser.add_argument(
-        "--variable",
-        required=True,
-        help="variable to download, 2m_temperature, total_precipitation",
-    )
-    parser.add_argument("--downloaddir", required=True, help="location to download to")
-    parser.add_argument(
-        "--years",
-        required=False,
-        help="Years to rerieve data for (comma separated). Optional. Default is hindcast period 1993-2016.",
-    )
-
-    args = parser.parse_args()
-    return args
-
-
 def main():
     """
     Called when this is run as a script
@@ -152,77 +116,84 @@ def main():
     Call the main funciton to do the actual
     cdsapi call
     """
-
-    # get command line args
-    args = parse_args()
-
-    # unpack args and reformat if needed
-    centre = args.centre
-    downloaddir = args.downloaddir
-    leadtime_month = [int(l) for l in args.leads.split(",")]
-    area = [float(pt) for pt in args.area.split(",")]
-    area_str = args.area.replace(",", ":")
-    month = int(args.month)
-    variable = str(args.variable)
-
     # get remaning arguments from yml file
-    ymllocation = os.path.join(downloaddir, "parseyml.yml")
+    ymllocation = os.path.join("variables.yml")
 
     with open(ymllocation, "r") as stream:
         try:
+            print('yml found')
             # Converts yaml document to python object
-            services = yaml.load(stream, Loader=SafeLoader)
+            config_test = yaml.load(stream, Loader=SafeLoader)
             # Converts contents to useable dictionary
-            Services = services["Services"]
+            Services = config_test["Services"]
+            Month_test = config_test["month"]
+            leads_test = config_test["leads"]
+            area_test = config_test["area"]
+            varaible_test = config_test["variable"]
+            downloaddir_test = config_test["downloaddir"]
+            years = config_test["years"]
+            centre = config_test["centre"]
+            print('yml success')
         except yaml.YAMLError as e:
             print(e)
+    
+    # unpack args and reformat if needed
+    centre = centre
+    downloaddir_test = os.path.expandvars(downloaddir_test)
+    downloaddir = downloaddir_test
+    leadtime_month = [int(l) for l in leads_test.split(",")]
+    area = [float(pt) for pt in area_test.split(",")]
+    area_str = area_test.replace(",", ":")
+    month = int(Month_test)
+    variable = str(varaible_test)
 
-    area = [float(pt) for pt in args.area.split(",")]
+    area = [float(pt) for pt in area_test.split(",")]
     if len(area) != 4:
         raise ValueError(f"Need 4 points for area: {area}")
-    if args.years:
-        years = [int(yr) for yr in args.years.split(",")]
+    if years:
+        years = [int(yr) for yr in years.split(",")]
     else:
         years = "hc"
-
-    if centre == "eccc":
-        # two models aka systems are live - call twice with each system number
-        do_cdsapi_call(
-            "eccc",
-            Services["eccc_can"],
-            month,
-            leadtime_month,
-            area,
-            area_str,
-            variable,
-            downloaddir,
-            years,
-        )
-        do_cdsapi_call(
-            "eccc",
-            Services["eccc_gem5"],
-            month,
-            leadtime_month,
-            area,
-            area_str,
-            variable,
-            downloaddir,
-            years,
-        )
-    else:
-        if centre not in Services.keys():
-            raise ValueError(f"Unknown system for C3S: {centre}")
-        do_cdsapi_call(
-            centre,
-            Services[centre],
-            month,
-            leadtime_month,
-            area,
-            area_str,
-            variable,
-            downloaddir,
-            years,
-        )
+    
+    for centre in config_test["centre"]:
+        if centre == "eccc":
+            # two models aka systems are live - call twice with each system number
+            do_cdsapi_call(
+                "eccc",
+                Services["eccc_can"],
+                month,
+                leadtime_month,
+                area,
+                area_str,
+                variable,
+                downloaddir,
+                years,
+            )
+            do_cdsapi_call(
+                "eccc",
+                Services["eccc_gem5"],
+                month,
+                leadtime_month,
+                area,
+                area_str,
+                variable,
+                downloaddir,
+                years,
+            )
+        else:
+            if centre not in Services.keys():
+                raise ValueError(f"Unknown system for C3S: {centre}")
+            do_cdsapi_call(
+                centre,
+                Services[centre],
+                month,
+                leadtime_month,
+                area,
+                area_str,
+                variable,
+                downloaddir,
+                years,
+            )
 
 
 if __name__ == "__main__":

--- a/scripts/get_era5.py
+++ b/scripts/get_era5.py
@@ -81,6 +81,8 @@ if __name__ == "__main__":
             print(e)
 
     #Make directory if it dosnt exist. 
+
+    downloaddir_test = os.path.expandvars(downloaddir_test)
     os.makedirs(downloaddir_test, exist_ok=True)
 
     # unpack args and reformat if needed

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -85,12 +85,6 @@ fi
 for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc ;do 
     set +e
     python get_any_hindcast.py \
-        --centre $centre \
-        --month $month \
-        --leads $leads \
-        --area $area \
-        --variable $variable\
-        --downloaddir $downloaddir \
         > $logdir/download_log_${variable}_${centre}.txt 2>&1
     exitcode=$?
     set -e
@@ -102,13 +96,6 @@ for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc ;do
     # compute terciles and anomalies
     set +e
     python compute_products.py \
-        --centre $centre \
-        --month $month \
-        --leads $leads \
-        --area $area \
-        --variable $variable \
-        --downloaddir $downloaddir \
-        --productsdir $productsdir \
         > $logdir/product_log_${variable}_${centre}.txt 2>&1
     exitcode=$?
     set -e
@@ -120,14 +107,6 @@ for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc ;do
     # calculate verification scores
     set +e
     python compute_scores.py \
-        --centre $centre \
-        --month $month \
-        --leads $leads \
-        --area $area \
-        --downloaddir $downloaddir \
-        --scoresdir $scoresdir \
-        --productsdir $productsdir \
-        --variable $variable \
         > $logdir/verification_log_${variable}_${centre}.txt 2>&1
     exitcode=$?
     set -e
@@ -139,15 +118,6 @@ for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc ;do
     # plot scores
         set +e
     python plot_verification.py \
-        --location $location \
-        --centre $centre \
-        --month $month \
-        --leads $leads \
-        --area $area \
-        --downloaddir $downloaddir \
-        --scoresdir $scoresdir \
-        --plotdir $plotdir \
-        --variable $variable \
         > $logdir/plot_log_${variable}_${centre}.txt 2>&1
     exitcode=$?
     set -e

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -22,16 +22,10 @@ conda activate osop
 set -u
 
 # pick download location
-downloaddir=$SCRATCH/seafoam/data/master/hindcast/downloads
-productsdir=$SCRATCH/seafoam/data/master/hindcast/products
-scoresdir=$SCRATCH/seafoam/data/master/hindcast/scores
-plotdir=$SCRATCH/seafoam/data/master/hindcast/plots
+
 logdir=$SCRATCH/seafoam/data/master/hindcast/logfiles
-mkdir -p $downloaddir
-mkdir -p $plotdir
 mkdir -p $logdir
-mkdir -p $productsdir
-mkdir -p $scoresdir
+
 
 # set PYTHONPATH relative to this location
 lib_path=$(pushd ./../lib > /dev/null && pwd && popd > /dev/null)
@@ -39,39 +33,13 @@ set +u
 export PYTHONPATH=$PYTHONPATH:$lib_path
 set -u
 
-#create a yml file to pass dictionary parameters
-parseyml="$downloaddir/parseyml.yml"
 
-# set parameters
-month=5 # initialisation month
-leads="2,3,4" # e.g. if month=5 and leads="2,3,4", valid months are JJA (6,7,8)
-area="45,-30,-2.5,60" # sub-area in degrees for area of interest (comma separated N,W,S,E)
 variable="total_precipitation" # variable of interest, typically "2m_temperature" or "total_precipitation"
-location="Morocco" #Current options include 'None' - no borders, 'UK','Morocco' and 'SAU' - Saudi Arabia
 
-# Services in use:
-cat <<EOF > "$parseyml"
-Services:
-    ecmwf: 51
-    meteo_france: 9
-    dwd: 22
-    cmcc: 35
-    ncep: 2
-    jma: 3
-    eccc_can: 4
-    eccc_gem5: 5
-    ukmo: 604
-EOF
-echo "YML file created: $parseyml"
 
 # get ERA5 data
 set +e
 python get_era5.py \
-    --month $month \
-    --leads $leads \
-    --area $area \
-    --downloaddir $downloaddir \
-    --variable $variable \
     > $logdir/era5_log_${variable}.txt 2>&1
 exitcode=$?
 set -e

--- a/scripts/master.test.sh
+++ b/scripts/master.test.sh
@@ -22,16 +22,29 @@ conda activate osop
 set -u
 
 # pick download location
+# YAML="variables.yml"
+# variable=$(awk -F':' '/^[[:space:]]*variable:/ {split($2, val, "#"); gsub(/^[ \t]+|[ \t]+$/, "", val[1]); print val[1]}' "$YAML")
+# logdir=$(awk -F':' '/^[[:space:]]*logdir:/ {split($2, val, "#"); gsub(/^[ \t]+|[ \t]+$/, "", val[1]); print val[1]}' "$YAML")
+# echo "Logdir: $logdir"
+# mkdir -p $logdir
 
-logdir=$SCRATCH/seafoam/data/master/hindcast/logfiles
-mkdir -p $logdir
 
 
 # set PYTHONPATH relative to this location
 lib_path=$(pushd ./../lib > /dev/null && pwd && popd > /dev/null)
 export PYTHONPATH=${PYTHONPATH:+$PYTHONPATH:}$lib_path
 
-variable="2m_temperature" # variable of interest, typically "2m_temperature" or "total_precipitation"
+
+variable="total_precipitation" # variable of interest, typically "2m_temperature" or "total_precipitation"
+logdir=$SCRATCH/seafoam/data/master/hindcast/logfiles
+mkdir -p $logdir
+
+
+
+
+
+
+
 
 
 # get ERA5 data

--- a/scripts/plot_verification.py
+++ b/scripts/plot_verification.py
@@ -6,7 +6,6 @@ See LICENSE in the root of the repository for full licensing details.
 """
 
 # Ensure the top level directory has been added to PYTHONPATH
-import argparse
 
 # Import functions 
 import os
@@ -15,46 +14,6 @@ from yaml.loader import SafeLoader
 
 #import needed local functions
 from osop.plot_verify import generate_plots, prep_titles
-
-
-
-
-def parse_args():
-    """
-    set up argparse to get command line arguments
-
-    Returns:
-        args: argparse args object
-    """
-
-    parser = argparse.ArgumentParser()
-    parser.add_argument("--location", required=True)
-    parser.add_argument("--centre", required=True, help="centre to download")
-    parser.add_argument("--month", required=True, help="start month for hindcasts")
-    parser.add_argument(
-        "--variable",
-        required=True,
-        help="variable to verify. 2m_temperature or total_precipitation",
-    )
-    parser.add_argument(
-        "--leads", required=True, help="forecast range in months (comma separated)"
-    )
-    parser.add_argument(
-        "--area",
-        required=True,
-        help="sub-area in degrees for retrieval (comma separated N,W,S,E)",
-    )
-    parser.add_argument("--downloaddir", required=True, help="location to get grib from")
-    parser.add_argument("--scoresdir", required=True, help="location for grab files")
-    parser.add_argument("--plotdir", required=True, help="location to download output to")
-    parser.add_argument(
-        "--years",
-        required=False,
-        help="Years to rerieve data for (comma separated). Optional. Default is hindcast period 1993-2016.",
-    )
-
-    args = parser.parse_args()
-    return args
 
 
 if __name__ == "__main__":
@@ -66,22 +25,46 @@ if __name__ == "__main__":
     scores = ["spearman_corr","pearson_corr", "roc", "rocss", "rps", "rel", "bs"]
 
     # get command line args
-    args = parse_args()
+    ymllocation = os.path.join("variables.yml")
+    with open(ymllocation, "r") as stream:
+        try:
+            print('yml found')
+            # Converts yaml document to python object
+            config_test = yaml.load(stream, Loader=SafeLoader)
+            # Converts contents to useable dictionary
+            Services = config_test["Services"]
+            Month_test = config_test["month"]
+            leads_test = config_test["leads"]
+            area_test = config_test["area"]
+            varaible_test = config_test["variable"]
+            location_test = config_test["location"]
+            downloaddir_test = config_test["downloaddir"]
+            scoresdir = config_test["scoresdir"]
+            plotsdir = config_test["plotdir"]
+            years = config_test["years"]
+            centre = config_test["centre"]
+            print('yml success')
+        except yaml.YAMLError as e:
+            print(e)
+    
+    downloaddir_test = os.path.expandvars(downloaddir_test)
+    scoresdir = os.path.expandvars(scoresdir)
+    plotsdir = os.path.expandvars(plotsdir)
+    os.makedirs(plotsdir, exist_ok=True)
 
     # unpack args and reformat if needed
-    border = args.location
-    centre = args.centre
-    downloaddir = args.downloaddir
-    scoresdir = args.scoresdir
-    plotdir = args.plotdir
-    month = int(args.month)
-    leads = args.leads
-    leadtime_month = [int(l) for l in args.leads.split(",")]
+    border = location_test
+    downloaddir = downloaddir_test
+    scoresdir = scoresdir
+    plotdir = plotsdir
+    month = int(Month_test)
+    leads = leads_test
+    leadtime_month = [int(l) for l in leads_test.split(",")]
     leads_str = "".join([str(mon) for mon in leadtime_month])
     obs_str = "".join([str(mon - 1) for mon in leadtime_month])
-    area = [float(pt) for pt in args.area.split(",")]
-    area_str = args.area.replace(",", ":")
-    fname_var = args.variable
+    area = [float(pt) for pt in area_test.split(",")]
+    area_str = area_test.replace(",", ":")
+    fname_var = varaible_test
 
     if fname_var == "2m_temperature":
         var = "t2m"
@@ -97,7 +80,6 @@ if __name__ == "__main__":
         border = border,
         start_month=month,
         valid_month=valid_month,
-        origin=centre,
         area_str=area_str,
         leads_str=leads_str,
         obs_str=obs_str,
@@ -105,47 +87,38 @@ if __name__ == "__main__":
         var=var,
     )
 
-    # get remaning arguments from yml file
-    ymllocation = os.path.join(downloaddir, "parseyml.yml")
 
-    with open(ymllocation, "r") as stream:
-        try:
-            # Converts yaml document to python object
-            services = yaml.load(stream, Loader=SafeLoader)
-            # Converts contents to useable dictionary
-            Services = services["Services"]
-        except yaml.YAMLError as e:
-            print(e)
-
-    if args.years:
-        config["hcstarty"] = args.years[0]
-        config["hcendy"] = args.years[1]
+    if years:
+        config["hcstarty"] = years[0]
+        config["hcendy"] = years[1]
     else:
         config["hcstarty"] = 1993
         config["hcendy"] = 2016
 
-    for score in scores:
-        for aggr in ["1m", "3m"]:
-            config["aggr"] = aggr
-            config["score"] = score
+    for centre in config_test["centre"]:
+        config["origin"] = centre
+        for score in scores:
+            for aggr in ["1m", "3m"]:
+                config["aggr"] = aggr
+                config["score"] = score
 
-            # run for appropriate system
-            if centre == "eccc":
-                # two models aka systems are live - call twice with each system number
-                config["system"] = Services["eccc_can"]
-                ## set titles
-                titles = prep_titles(config)
-                generate_plots(config, titles, scoresdir, plotdir)
+                # run for appropriate system
+                if centre == "eccc":
+                    # two models aka systems are live - call twice with each system number
+                    config["system"] = Services["eccc_can"]
+                    ## set titles
+                    titles = prep_titles(config)
+                    generate_plots(config, titles, scoresdir, plotdir)
 
-                ## repeat for second system
-                config["system"] = Services["eccc_gem5"]
-                ## set titles
-                titles = prep_titles(config)
-                generate_plots(config, titles, scoresdir, plotdir)
-            else:
-                if centre not in Services.keys():
-                    raise ValueError(f"Unknown system for C3S: {centre}")
-                config["system"] = Services[centre]
-                ## set titles
-                titles = prep_titles(config)
-                generate_plots(config, titles, scoresdir, plotdir)
+                    ## repeat for second system
+                    config["system"] = Services["eccc_gem5"]
+                    ## set titles
+                    titles = prep_titles(config)
+                    generate_plots(config, titles, scoresdir, plotdir)
+                else:
+                    if centre not in Services.keys():
+                        raise ValueError(f"Unknown system for C3S: {centre}")
+                    config["system"] = Services[centre]
+                    ## set titles
+                    titles = prep_titles(config)
+                    generate_plots(config, titles, scoresdir, plotdir)

--- a/scripts/variables.yml
+++ b/scripts/variables.yml
@@ -1,0 +1,30 @@
+#Edit Variables appropriately
+
+#Service and relevent version 
+Services:
+    ecmwf: 51
+    meteo_france: 9
+    dwd: 22
+    cmcc: 35
+    ncep: 2
+    jma: 3
+    eccc_can: 4
+    eccc_gem5: 5
+    ukmo: 604
+
+# set General parameters 
+month: 5 # initialisation month
+leads: "2,3,4" # e.g. if month=5 and leads="2,3,4", valid months are JJA (6,7,8)
+area: "45,-30,-2.5,60" # sub-area in degrees for area of interest (comma separated N,W,S,E)
+variable: "2m_temperature" # variable of interest, typically "2m_temperature" or "total_precipitation"
+location: "Morocco" #Current options include 'None' - no borders, 'UK','Morocco' and 'SAU' - Saudi Arabia
+
+#Hindcast
+downloaddir: "$SCRATCH/seafoam/data/master/hindcast/downloads"
+productsdir: "$SCRATCH/seafoam/data/master/hindcast/products"
+scoresdir: "$SCRATCH/seafoam/data/master/hindcast/scores"
+plotdir: "$SCRATCH/seafoam/data/master/hindcast/plots"
+logdir: "$SCRATCH/seafoam/data/master/hindcast/logfiles"
+years: False #If hindcast years need to be cut down write as such - [1997,2000]
+
+#Forecast

--- a/scripts/variables.yml
+++ b/scripts/variables.yml
@@ -20,11 +20,13 @@ variable: "2m_temperature" # variable of interest, typically "2m_temperature" or
 location: "Morocco" #Current options include 'None' - no borders, 'UK','Morocco' and 'SAU' - Saudi Arabia
 
 #Hindcast
-downloaddir: "$SCRATCH/seafoam/data/master/hindcast/downloads"
+downloaddir: "$SCRATCH/seafoam/data/master/hindcast/downloads/x"
 productsdir: "$SCRATCH/seafoam/data/master/hindcast/products"
-scoresdir: "$SCRATCH/seafoam/data/master/hindcast/scores"
+scoresdir: "$SCRATCH/seafoam/data/master/hindcast/scores/x"
 plotdir: "$SCRATCH/seafoam/data/master/hindcast/plots"
 logdir: "$SCRATCH/seafoam/data/master/hindcast/logfiles"
 years: False #If hindcast years need to be cut down write as such - [1997,2000]
+centre: ["meteo_france","dwd","cmcc","ncep","ukmo","ecmwf","jma","eccc"]
+obs: False
 
 #Forecast


### PR DESCRIPTION
Basis for moving variables, services and directory management over to yml file. Currently, functional for hindcasts (master.sh and master.test.sh) however parse args still exists in master.forecast.sh so full functionality is preserved. 
Minor issues revolve around the shell script log files - specifically they need a variable, centre and a location. This is requiring passing from the Yaml file to the bash code. Testing of this is laid out in most recent commit in # lines but comes with some issues of it passing as a string so log files end up having '' around their names and the location sometimes adding to the end of the lib path (an issue avoided in the python with os.expandpath). The other issue is time taken, the yaml loader through python is slow in comparison to parse args. Notions of speeding it up do seem to exist https://stackoverflow.com/questions/27743711/can-i-speedup-yaml but will be something worth consideration before further development.