### PR TITLE
Backtracking for up-to-date services. 

### DIFF
--- a/scripts/get_any_hindcast.py
+++ b/scripts/get_any_hindcast.py
@@ -93,21 +93,39 @@ def do_cdsapi_call(
     if os.path.exists(fname):
         print(f"File {fname} already exists")
     else:
-        c.retrieve(
-            "seasonal-monthly-single-levels",
-            {
-                "format": "grib",
-                "originating_centre": f"{centre}",
-                "system": system,
-                "variable": [variable],
-                "product_type": "monthly_mean",
-                "year": years,
-                "month": "{:02d}".format(month),
-                "leadtime_month": leadtime_month,
-                "area": area,
-            },
-            f"{downloaddir}/{centre}_{system}_{years[0]}-{years[-1]}_monthly_mean_{month}_{leads_str}_{area_str}_{variable}.grib",
-        )
+        try:
+            c.retrieve(
+                "seasonal-monthly-single-levels",
+                {
+                    "format": "grib",
+                    "originating_centre": f"{centre}",
+                    "system": system,
+                    "variable": [variable],
+                    "product_type": "monthly_mean",
+                    "year": years,
+                    "month": "{:02d}".format(month),
+                    "leadtime_month": leadtime_month,
+                    "area": area,
+                },
+                f"{downloaddir}/{centre}_{system}_{years[0]}-{years[-1]}_monthly_mean_{month}_{leads_str}_{area_str}_{variable}.grib",
+            )
+        except:
+            print("system is incorrect... trying previous system...")
+            c.retrieve(
+                "seasonal-monthly-single-levels",
+                {
+                    "format": "grib",
+                    "originating_centre": f"{centre}",
+                    "system": system -1 ,
+                    "variable": [variable],
+                    "product_type": "monthly_mean",
+                    "year": years,
+                    "month": "{:02d}".format(month),
+                    "leadtime_month": leadtime_month,
+                    "area": area,
+                },
+                f"{downloaddir}/{centre}_{system}_{years[0]}-{years[-1]}_monthly_mean_{month}_{leads_str}_{area_str}_{variable}.grib",
+            )
 
 
 def parse_args():


### PR DESCRIPTION
Some services are updated mid-year, i.e. Meteo_france went from 8 to 9 in April. The resolution of this is that if you try to forecast for February you need to run for service 8 but if you want to run a forecast initialized in may you need to run service 9. This is easily modifiable (especially under the yaml branch) but can cause confusion in new users. To increase user compatibility when learning the tools a backtrack feature is added. If the theoretical date dosnt exist the aim would be that it backtracks and try's the service model before. If it fails again then it would need to be looked at by the user. It will print a warning to let the user know this has happened and ideally for them to fix for next run. Currently, a conceptualization rather than an attempt to actually implement. 