### PR TITLE
mme_hindcast

### DIFF
--- a/lib/osop/util.py
+++ b/lib/osop/util.py
@@ -103,7 +103,7 @@ def get_tindex(infile):
 
 
 # move
-def index(forecast_local, st_dim_name):
+def index(forecast_local, st_dim_name, productsdir, hcst_bname):
     """
     Reindex and restyle the forcast grib so that the data layout is consistent
     and compatiable with hindcast terciles.
@@ -129,4 +129,6 @@ def index(forecast_local, st_dim_name):
     forecast_data = forecast_data.rename(
         {"latitude": "lat", "longitude": "lon", st_dim_name: "start_date"}
     )
+    print(f"Saving index netCDF files")
+    forecast_data.to_netcdf(f"{productsdir}/{hcst_bname}.index.nc")
     return forecast_data

--- a/scripts/compute_products.py
+++ b/scripts/compute_products.py
@@ -15,7 +15,7 @@ from yaml.loader import SafeLoader
 
 
 # import needed local functions
-from osop.compute_products_func import calc_products
+from osop.compute_products_func import calc_products, calc_products_mme, mme_products_hindcast
 
 
 def parse_args():
@@ -114,6 +114,9 @@ if __name__ == "__main__":
         ## repeat for second system
         config["system"] = Services["eccc_gem5"]
         calc_products(config, downloaddir, productsdir)
+    elif centre == "mme":
+        config["systemfc"] = Services["mme"]
+        calc_products_mme(Services, config, productsdir)
     else:
         if centre not in Services.keys():
             raise ValueError(f"Unknown system for C3S: {centre}")

--- a/scripts/master.sh
+++ b/scripts/master.sh
@@ -61,6 +61,7 @@ Services:
     eccc_can: 4
     eccc_gem5: 5
     ukmo: 604
+    mme: 1
 EOF
 echo "YML file created: $parseyml"
 
@@ -81,23 +82,25 @@ else
     echo era5 download failed
 fi
 
-# loop over all centres of interest and get data
-for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc ;do 
-    set +e
-    python get_any_hindcast.py \
-        --centre $centre \
-        --month $month \
-        --leads $leads \
-        --area $area \
-        --variable $variable\
-        --downloaddir $downloaddir \
-        --logdir $logdir
-    exitcode=$?
-    set -e
-    if [ $exitcode -eq 0 ]; then
-        echo $centre : download sucessful
-    else
-        echo $centre : download failed
+# loop over all centres of interest and get data #for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc mme ;do 
+for centre in meteo_france dwd cmcc ncep ukmo ecmwf jma eccc mme ;do 
+    if [ "$centre" != "mme" ]; then
+        set +e
+        python get_any_hindcast.py \
+            --centre $centre \
+            --month $month \
+            --leads $leads \
+            --area $area \
+            --variable $variable\
+            --downloaddir $downloaddir \
+            --logdir $logdir
+        exitcode=$?
+        set -e
+        if [ $exitcode -eq 0 ]; then
+            echo $centre : download sucessful
+        else
+            echo $centre : download failed
+        fi
     fi
     # compute terciles and anomalies
     set +e


### PR DESCRIPTION
**AIM**: To add hindcast verifications scores for mme system. 
**Changes**: Currently producing mme hindcast verification. Got some issues I'd like to address before merging. Thoughts about making sure a user uses the same services make up for the verification as well as the forecasts. Possibility of moving the mme hindcast to the forecast shell pipeline to force this. However makes less sense in makeup. Do we leave it up to user discretion? Theoretically choices come from the yml so possible making this only editable in the master.sh script will force people to A) do the master shell first and B) makes sure the set-up is the same. 
**ISSUES**: Lots of this code still needs commenting and better naming as well as reducing redundancy. Hence, Draft PR.

**CHECKS**: Code seems to make coherent sense. Plot outputs match https://confluence.ecmwf.int/display/CKB/C3S+seasonal+forecasts+verification+plots

Set up: Initialisation May, forecast JJA, Chart C3S 2025.

<img width="829" height="430" alt="image" src="https://github.com/user-attachments/assets/85ee6722-beba-40ec-841b-a004e21b61f1" />

 