### PR TITLE
pcolourmesh

### DIFF
--- a/scripts/master.test.sh
+++ b/scripts/master.test.sh
@@ -46,6 +46,7 @@ leads="2,3,4" # e.g. if month=5 and leads="2,3,4", valid months are JJA (6,7,8)
 area="45,-30,-2.5,60" # sub-area in degrees for area of interest (comma separated N,W,S,E)
 variable="2m_temperature" # variable of interest, typically "2m_temperature" or "total_precipitation"
 location="Morocco" #Current options include 'None' - no borders, 'UK','Morocco' and 'SAU' - Saudi Arabia
+method="pmesh" #Changes plot looks, remove for standard.
 
 # Services in use:
 cat <<EOF > "$parseyml"
@@ -148,6 +149,7 @@ for centre in meteo_france ;do
         --scoresdir $scoresdir \
         --plotdir $plotdir \
         --variable $variable \
+        --method $method \
         > $logdir/plot_log_${variable}_${centre}.txt 2>&1
     exitcode=$?
     set -e

--- a/scripts/plot_verification.py
+++ b/scripts/plot_verification.py
@@ -54,6 +54,12 @@ def parse_args():
         required=False,
         help="Years to rerieve data for (comma separated). Optional. Default is hindcast period 1993-2016.",
     )
+    parser.add_argument(
+        "--method",
+        required=False,
+        default = None,
+        help="Changes the plotting look, use pmesh for pcolourmesh",
+    )
 
     args = parser.parse_args()
     return args
@@ -71,6 +77,7 @@ if __name__ == "__main__":
     args = parse_args()
 
     # unpack args and reformat if needed
+    method = args.method
     border = args.location
     centre = args.centre
     downloaddir = args.downloaddir
@@ -137,17 +144,17 @@ if __name__ == "__main__":
                 config["system"] = Services["eccc_can"]
                 ## set titles
                 titles = prep_titles(config)
-                generate_plots(config, titles, scoresdir, plotdir)
+                generate_plots(config, titles, scoresdir, plotdir, method)
 
                 ## repeat for second system
                 config["system"] = Services["eccc_gem5"]
                 ## set titles
                 titles = prep_titles(config)
-                generate_plots(config, titles, scoresdir, plotdir)
+                generate_plots(config, titles, scoresdir, plotdir, method)
             else:
                 if centre not in Services.keys():
                     raise ValueError(f"Unknown system for C3S: {centre}")
                 config["system"] = Services[centre]
                 ## set titles
                 titles = prep_titles(config)
-                generate_plots(config, titles, scoresdir, plotdir)
+                generate_plots(config, titles, scoresdir, plotdir, method)


### PR DESCRIPTION
This adds pcolormesh for correlation plots. Its decidable in the shell. If removed from the shell or method is not set to equal "pmesh" it will plot as it has been doing with the smoothed plots. If `method="pmesh`" is included in the pass to plot_verififcation.py then the correlation plots will have pcolormesh. 
<img width="602" height="314" alt="image" src="https://github.com/user-attachments/assets/5f92b49c-55b2-4244-95a7-1782b1a47680" />
<img width="940" height="493" alt="image" src="https://github.com/user-attachments/assets/22767007-29c8-4a03-962c-fa4bc7007297" />

This change is helping with detail loss when zoomed in on smaller locals; This is the original:
<img width="67" height="41" alt="image" src="https://github.com/user-attachments/assets/8d888d04-45a1-40a1-a320-338ff1c0b0db" />
<img width="1179" height="972" alt="image" src="https://github.com/user-attachments/assets/7c39993e-fffa-4b86-b716-486b1a444de0" />

This is it with pcolourmesh:
<img width="69" height="45" alt="image" src="https://github.com/user-attachments/assets/1c4ef8ef-9486-4471-8b76-fee0c15e4640" />
<img width="940" height="780" alt="image" src="https://github.com/user-attachments/assets/c3d060c9-9777-45d3-acff-ac013e86fab3" />


**Improvement needed**: This will work merged in as it is but needs to be expanded to the probabilistic scores